### PR TITLE
Add chat usage telemetry to responses

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -210,7 +210,7 @@ body {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.45rem;
+  gap: 0.35rem;
   font-size: 0.7rem;
   color: #94a3b8;
 }
@@ -223,8 +223,28 @@ body {
 }
 
 .session-stats__item {
-  background: rgba(79, 70, 229, 0.18);
-  border: 1px solid rgba(129, 140, 248, 0.2);
+  display: inline-flex;
+  flex-direction: row;
+  align-items: baseline;
+  gap: 0.4rem;
+  padding: 0.2rem 0.65rem;
+  border-radius: 9999px;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(71, 85, 105, 0.55);
+  color: #cbd5f5;
+  backdrop-filter: blur(8px);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.6);
+}
+
+.session-stats__item .bubble-footer__name {
+  font-size: 0.55rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.8;
+}
+
+.session-stats__item .bubble-footer__value {
+  font-size: 0.75rem;
 }
 
 .fade-in-up {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -20,18 +20,25 @@ body {
 
 .bubble-footer__item {
   display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  padding: 0.15rem 0.5rem;
+  flex-direction: column;
+  gap: 0.1rem;
+  padding: 0.25rem 0.55rem;
   border-radius: 9999px;
   background: rgba(148, 163, 184, 0.12);
   color: inherit;
   backdrop-filter: blur(6px);
 }
 
-.bubble-footer__icon {
-  font-size: 0.7rem;
-  line-height: 1;
+.bubble-footer__name {
+  font-size: 0.6rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0.85;
+}
+
+.bubble-footer__value {
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
 }
 
 .session-stats {
@@ -54,10 +61,6 @@ body {
 .session-stats__item {
   background: rgba(79, 70, 229, 0.18);
   border: 1px solid rgba(129, 140, 248, 0.2);
-}
-
-.session-stats__item .bubble-footer__icon {
-  font-size: 0.75rem;
 }
 
 .fade-in-up {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -8,6 +8,58 @@ body {
   background-color: #020617;
 }
 
+.bubble-footer {
+  margin-top: 0.75rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  font-size: 0.65rem;
+  line-height: 1.1;
+  color: #94a3b8;
+}
+
+.bubble-footer__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 9999px;
+  background: rgba(148, 163, 184, 0.12);
+  color: inherit;
+  backdrop-filter: blur(6px);
+}
+
+.bubble-footer__icon {
+  font-size: 0.7rem;
+  line-height: 1;
+}
+
+.session-stats {
+  margin-bottom: 0.75rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.7rem;
+  color: #94a3b8;
+}
+
+.session-stats__label {
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #cbd5f5;
+}
+
+.session-stats__item {
+  background: rgba(79, 70, 229, 0.18);
+  border: 1px solid rgba(129, 140, 248, 0.2);
+}
+
+.session-stats__item .bubble-footer__icon {
+  font-size: 0.75rem;
+}
+
 .fade-in-up {
   animation: fade-in-up 0.35s ease-out both;
 }

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -8,6 +8,170 @@ body {
   background-color: #020617;
 }
 
+.button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  border-radius: 0.75rem;
+  border: 1px solid transparent;
+  background: rgba(148, 163, 184, 0.08);
+  color: #cbd5f5;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  padding: 0.45rem 0.9rem;
+  line-height: 1;
+  transition: transform 180ms ease, background-color 180ms ease, border-color 180ms ease,
+    box-shadow 220ms ease;
+}
+
+.button.hidden,
+.hidden.button {
+  display: none !important;
+}
+
+.button::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  opacity: 0;
+  transition: opacity 200ms ease;
+  pointer-events: none;
+}
+
+.button:hover {
+  transform: translateY(-1px);
+  background: rgba(148, 163, 184, 0.16);
+  border-color: rgba(148, 163, 184, 0.3);
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.38);
+}
+
+.button:hover::after {
+  opacity: 1;
+}
+
+.button:active {
+  transform: translateY(0);
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.32);
+}
+
+.button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(45, 212, 191, 0.3), 0 0 0 1px rgba(14, 116, 144, 0.8);
+}
+
+.button svg {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.button--ghost {
+  background: rgba(30, 41, 59, 0.6);
+  border-color: rgba(148, 163, 184, 0.12);
+  color: #cbd5f5;
+}
+
+.button--ghost:hover {
+  background: rgba(51, 65, 85, 0.7);
+  border-color: rgba(148, 163, 184, 0.24);
+}
+
+.button--primary {
+  background: linear-gradient(135deg, #4f46e5, #7c3aed);
+  border-color: rgba(129, 140, 248, 0.5);
+  color: #f8fafc;
+  box-shadow: 0 14px 40px rgba(99, 102, 241, 0.42);
+}
+
+.button--primary:hover {
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  border-color: rgba(129, 140, 248, 0.65);
+}
+
+.button--primary:active {
+  box-shadow: 0 10px 24px rgba(79, 70, 229, 0.45);
+}
+
+.button--danger {
+  background: linear-gradient(135deg, #f43f5e, #fb7185);
+  border-color: rgba(248, 113, 113, 0.5);
+  color: #fff1f2;
+  box-shadow: 0 14px 36px rgba(244, 63, 94, 0.4);
+}
+
+.button--danger:hover {
+  background: linear-gradient(135deg, #fb7185, #f43f5e);
+  border-color: rgba(248, 113, 113, 0.7);
+}
+
+.button--icon {
+  width: 2.4rem;
+  height: 2.4rem;
+  padding: 0.45rem;
+}
+
+.button--icon-sm {
+  width: 2rem;
+  height: 2rem;
+  padding: 0.35rem;
+}
+
+.button--icon-sm svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.button--square {
+  border-radius: 0.9rem;
+}
+
+.button--circle {
+  border-radius: 9999px;
+}
+
+.button--stacked {
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  font-size: 0.65rem;
+  line-height: 1.1;
+  padding: 0.75rem;
+  min-width: 3.1rem;
+}
+
+.button--block {
+  width: 100%;
+  justify-content: center;
+  padding-inline: 1.1rem;
+  min-height: 2.8rem;
+}
+
+.button--subtle {
+  background: rgba(15, 23, 42, 0.75);
+  border-color: rgba(51, 65, 85, 0.65);
+  color: #cbd5f5;
+}
+
+.button--subtle:hover {
+  background: rgba(30, 41, 59, 0.85);
+  border-color: rgba(71, 85, 105, 0.75);
+}
+
+.button--muted {
+  background: rgba(51, 65, 85, 0.55);
+  border-color: rgba(71, 85, 105, 0.6);
+}
+
+.button--muted:hover {
+  background: rgba(71, 85, 105, 0.65);
+  border-color: rgba(100, 116, 139, 0.6);
+}
+
 .bubble-footer {
   margin-top: 0.75rem;
   display: flex;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -21,6 +21,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const sendBtn = el("#sendBtn");
   const stopBtn = el("#stopBtn");
   const clearChatBtn = el("#clearChat");
+  const sessionStats = el("#sessionStats");
 
   // Settings Drawer
   const settingsOverlay = el("#settingsOverlay");
@@ -169,10 +170,108 @@ document.addEventListener("DOMContentLoaded", () => {
     contentDiv.innerHTML = content;
     bubble.appendChild(contentDiv);
 
+    let footer = null;
+    if (role === "ai") {
+      footer = document.createElement("div");
+      footer.className = "bubble-footer hidden";
+      bubble.appendChild(footer);
+    }
+
     wrapper.appendChild(bubble);
     chat.appendChild(wrapper);
     chat.scrollTop = chat.scrollHeight;
-    return contentDiv;
+    return { wrapper, bubble, content: contentDiv, footer };
+  }
+
+  function createFooterItem(icon, label, title = "") {
+    const span = document.createElement("span");
+    span.className = "bubble-footer__item";
+    if (title) span.title = title;
+
+    const iconSpan = document.createElement("span");
+    iconSpan.className = "bubble-footer__icon";
+    iconSpan.textContent = icon;
+    span.appendChild(iconSpan);
+
+    const labelSpan = document.createElement("span");
+    labelSpan.textContent = label;
+    span.appendChild(labelSpan);
+
+    return span;
+  }
+
+  function updateAssistantFooter(footerEl, metadata) {
+    if (!footerEl) return;
+
+    footerEl.innerHTML = "";
+    const segments = [];
+
+    const meta = metadata || {};
+    const { prompt, completion, total, serverLatency, roundTripMs } = meta;
+
+    if (typeof prompt === "number" && !Number.isNaN(prompt)) {
+      segments.push(createFooterItem("🧠", `${prompt.toLocaleString()} prompt`));
+    }
+    if (typeof completion === "number" && !Number.isNaN(completion)) {
+      segments.push(createFooterItem("✨", `${completion.toLocaleString()} completion`));
+    }
+    if (typeof total === "number" && !Number.isNaN(total)) {
+      segments.push(createFooterItem("Σ", `${total.toLocaleString()} total`));
+    }
+    if (typeof serverLatency === "number" && !Number.isNaN(serverLatency)) {
+      segments.push(createFooterItem("⚙️", `${serverLatency.toLocaleString()} ms`, "Server processing time"));
+    }
+    if (typeof roundTripMs === "number" && !Number.isNaN(roundTripMs)) {
+      segments.push(createFooterItem("⏱️", `${roundTripMs.toLocaleString()} ms`, "Round-trip time"));
+    }
+
+    if (!segments.length) {
+      footerEl.classList.add("hidden");
+      return;
+    }
+
+    segments.forEach((segment) => footerEl.appendChild(segment));
+    footerEl.classList.remove("hidden");
+  }
+
+  function updateSessionStats(totals) {
+    if (!sessionStats) return;
+
+    const hasTotals = totals && (typeof totals.total_tokens === "number" || typeof totals.prompt_tokens === "number" || typeof totals.completion_tokens === "number");
+    if (!hasTotals) {
+      sessionStats.classList.add("hidden");
+      sessionStats.innerHTML = "";
+      return;
+    }
+
+    const chips = [];
+    const promptTokens = totals.prompt_tokens;
+    const completionTokens = totals.completion_tokens;
+    const totalTokens = totals.total_tokens;
+
+    sessionStats.innerHTML = "";
+
+    const label = document.createElement("span");
+    label.className = "session-stats__label";
+    label.textContent = "Session";
+    sessionStats.appendChild(label);
+
+    if (typeof promptTokens === "number") {
+      chips.push(createFooterItem("🧠", `${promptTokens.toLocaleString()} prompt`));
+    }
+    if (typeof completionTokens === "number") {
+      chips.push(createFooterItem("✨", `${completionTokens.toLocaleString()} completion`));
+    }
+    if (typeof totalTokens === "number") {
+      chips.push(createFooterItem("Σ", `${totalTokens.toLocaleString()} total`));
+    }
+
+    chips.forEach((chip) => {
+      chip.classList.add("session-stats__item");
+      sessionStats.appendChild(chip);
+    });
+
+    sessionStats.classList.remove("hidden");
   }
 
   function getSettings() {
@@ -198,15 +297,17 @@ document.addEventListener("DOMContentLoaded", () => {
       removeImage();
     }
 
-    const aiBubble = addMessage("ai", "");
+    const aiMessage = addMessage("ai", "");
     const cursor = document.createElement("span");
     cursor.className = "typing";
     cursor.textContent = "▍";
-    aiBubble.appendChild(cursor);
+    aiMessage.content.appendChild(cursor);
 
     sendBtn.classList.add("hidden");
     stopBtn.classList.remove("hidden");
     controller = new AbortController();
+
+    const requestStarted = performance.now();
 
     try {
       const resp = await fetch("/api/chat", {
@@ -243,25 +344,42 @@ document.addEventListener("DOMContentLoaded", () => {
         responseText += decoder.decode(value, { stream: true });
         chat.scrollTop = chat.scrollHeight;
       }
-      
+
       try {
         const json = JSON.parse(responseText);
         if (json.reply) {
           const formattedReply = converter.makeHtml(json.reply);
-          aiBubble.innerHTML = formattedReply;
+          aiMessage.content.innerHTML = formattedReply;
         } else {
-            aiBubble.textContent = responseText;
+            aiMessage.content.textContent = responseText;
+        }
+
+        const usage = json.usage || {};
+        const metadata = {
+          prompt: typeof usage.prompt_tokens === "number" ? usage.prompt_tokens : Number.parseInt(usage.prompt_tokens, 10),
+          completion: typeof usage.completion_tokens === "number" ? usage.completion_tokens : Number.parseInt(usage.completion_tokens, 10),
+          total: typeof usage.total_tokens === "number" ? usage.total_tokens : Number.parseInt(usage.total_tokens, 10),
+          serverLatency: typeof json.latency_ms === "number" ? json.latency_ms : Number.parseInt(json.latency_ms, 10),
+          roundTripMs: Math.round(performance.now() - requestStarted),
+        };
+
+        updateAssistantFooter(aiMessage.footer, metadata);
+
+        if (json.session_totals) {
+          updateSessionStats(json.session_totals);
         }
       } catch (err) {
-        aiBubble.textContent = responseText;
+        aiMessage.content.textContent = responseText;
+        updateAssistantFooter(aiMessage.footer, null);
       }
 
     } catch (err) {
       if (err.name !== 'AbortError') {
-        aiBubble.textContent = `[Error: ${err.message}]`;
+        aiMessage.content.textContent = `[Error: ${err.message}]`;
+        updateAssistantFooter(aiMessage.footer, null);
       }
     } finally {
-      aiBubble.querySelector(".typing")?.remove();
+      aiMessage.content.querySelector(".typing")?.remove();
       sendBtn.classList.remove("hidden");
       stopBtn.classList.add("hidden");
       controller = null;
@@ -273,6 +391,7 @@ document.addEventListener("DOMContentLoaded", () => {
       await fetch("/api/reset", { method: "POST" });
       chat.innerHTML = '';
       addMessage('ai', 'Chat cleared.');
+      updateSessionStats(null);
       removeImage();
       notify("Chat history has been cleared.");
     } catch (err) {
@@ -435,5 +554,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // --- Init ---
   loadSettings();
+  updateSessionStats(null);
   fetchModels();
 });

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -183,19 +183,20 @@ document.addEventListener("DOMContentLoaded", () => {
     return { wrapper, bubble, content: contentDiv, footer };
   }
 
-  function createFooterItem(icon, label, title = "") {
+  function createFooterMetric(name, value, title = "") {
     const span = document.createElement("span");
     span.className = "bubble-footer__item";
     if (title) span.title = title;
 
-    const iconSpan = document.createElement("span");
-    iconSpan.className = "bubble-footer__icon";
-    iconSpan.textContent = icon;
-    span.appendChild(iconSpan);
+    const nameSpan = document.createElement("span");
+    nameSpan.className = "bubble-footer__name";
+    nameSpan.textContent = name;
+    span.appendChild(nameSpan);
 
-    const labelSpan = document.createElement("span");
-    labelSpan.textContent = label;
-    span.appendChild(labelSpan);
+    const valueSpan = document.createElement("span");
+    valueSpan.className = "bubble-footer__value";
+    valueSpan.textContent = value;
+    span.appendChild(valueSpan);
 
     return span;
   }
@@ -210,19 +211,37 @@ document.addEventListener("DOMContentLoaded", () => {
     const { prompt, completion, total, serverLatency, roundTripMs } = meta;
 
     if (typeof prompt === "number" && !Number.isNaN(prompt)) {
-      segments.push(createFooterItem("🧠", `${prompt.toLocaleString()} prompt`));
+      segments.push(
+        createFooterMetric("Prompt tokens", prompt.toLocaleString())
+      );
     }
     if (typeof completion === "number" && !Number.isNaN(completion)) {
-      segments.push(createFooterItem("✨", `${completion.toLocaleString()} completion`));
+      segments.push(
+        createFooterMetric("Completion tokens", completion.toLocaleString())
+      );
     }
     if (typeof total === "number" && !Number.isNaN(total)) {
-      segments.push(createFooterItem("Σ", `${total.toLocaleString()} total`));
+      segments.push(
+        createFooterMetric("Total tokens", total.toLocaleString())
+      );
     }
     if (typeof serverLatency === "number" && !Number.isNaN(serverLatency)) {
-      segments.push(createFooterItem("⚙️", `${serverLatency.toLocaleString()} ms`, "Server processing time"));
+      segments.push(
+        createFooterMetric(
+          "Model latency",
+          `${serverLatency.toLocaleString()} ms`,
+          "Server processing time"
+        )
+      );
     }
     if (typeof roundTripMs === "number" && !Number.isNaN(roundTripMs)) {
-      segments.push(createFooterItem("⏱️", `${roundTripMs.toLocaleString()} ms`, "Round-trip time"));
+      segments.push(
+        createFooterMetric(
+          "Round-trip latency",
+          `${roundTripMs.toLocaleString()} ms`,
+          "Request and response latency"
+        )
+      );
     }
 
     if (!segments.length) {
@@ -253,17 +272,26 @@ document.addEventListener("DOMContentLoaded", () => {
 
     const label = document.createElement("span");
     label.className = "session-stats__label";
-    label.textContent = "Session";
+    label.textContent = "Session usage";
     sessionStats.appendChild(label);
 
     if (typeof promptTokens === "number") {
-      chips.push(createFooterItem("🧠", `${promptTokens.toLocaleString()} prompt`));
+      chips.push(
+        createFooterMetric("Prompt tokens", promptTokens.toLocaleString())
+      );
     }
     if (typeof completionTokens === "number") {
-      chips.push(createFooterItem("✨", `${completionTokens.toLocaleString()} completion`));
+      chips.push(
+        createFooterMetric(
+          "Completion tokens",
+          completionTokens.toLocaleString()
+        )
+      );
     }
     if (typeof totalTokens === "number") {
-      chips.push(createFooterItem("Σ", `${totalTokens.toLocaleString()} total`));
+      chips.push(
+        createFooterMetric("Total tokens", totalTokens.toLocaleString())
+      );
     }
 
     chips.forEach((chip) => {

--- a/templates/index.html
+++ b/templates/index.html
@@ -84,6 +84,7 @@
             <input id="imageFileInput" type="file" accept="image/*" class="hidden">
             <input id="cameraFileInput" type="file" accept="image/*" capture="environment" class="hidden">
           </div>
+          <div id="sessionStats" class="session-stats hidden" aria-live="polite"></div>
           <div class="relative">
             <textarea id="userInput" rows="1" placeholder="Ask a question..." class="w-full resize-none rounded-lg border border-white/10 bg-slate-800/70 py-3 pl-4 pr-28 text-slate-100 placeholder:text-slate-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/50"></textarea>
             <div class="absolute bottom-2 right-2 flex items-center gap-2">

--- a/templates/index.html
+++ b/templates/index.html
@@ -42,10 +42,10 @@
             </div>
           </div>
           <div class="flex items-center gap-2">
-            <button id="clearChat" type="button" class="inline-flex h-9 items-center justify-center rounded-lg border border-white/10 bg-white/5 px-3 text-sm font-medium text-slate-300 transition hover:bg-white/10" title="Clear chat">
+            <button id="clearChat" type="button" class="button button--icon button--ghost" title="Clear chat">
               <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" /></svg>
             </button>
-            <button id="openSettings" type="button" class="inline-flex h-9 items-center justify-center rounded-lg border border-white/10 bg-white/5 px-3 text-sm font-medium text-slate-300 transition hover:bg-white/10" title="Settings">
+            <button id="openSettings" type="button" class="button button--icon button--ghost" title="Settings">
               <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 0 2l-.15.08a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.38a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1 0-2l.15-.08a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" /><circle cx="12" cy="12" r="3" /></svg>
             </button>
           </div>
@@ -67,16 +67,16 @@
                 <p id="imagePreviewMeta" class="text-xs font-medium text-slate-200"></p>
                 <p class="text-xs text-slate-400">Image attached</p>
               </div>
-              <button id="removeImageBtn" type="button" class="ml-auto h-7 w-7 rounded-full bg-white/10 text-slate-400 transition hover:bg-white/20 hover:text-white" title="Remove image">
+              <button id="removeImageBtn" type="button" class="ml-auto button button--icon-sm button--circle button--ghost" title="Remove image">
                 <svg class="m-auto h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
               </button>
             </div>
             <div id="visionActions" class="flex items-center gap-2">
-              <button id="imageUploadBtn" type="button" class="flex h-12 w-12 flex-col items-center justify-center rounded-lg bg-white/5 text-xs text-slate-300 transition hover:bg-white/10">
+              <button id="imageUploadBtn" type="button" class="button button--ghost button--stacked">
                 <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21.2 15c.7-1.2 1-2.5.7-3.9-.6-2.4-3-4-5.4-4-1.6 0-3.1.8-4.2 2.1-.5-.2-1-.3-1.5-.3-2.4 0-4.4 2-4.4 4.4 0 .4.1.8.2 1.2" /><path d="M11 18.5v-7.8l-2.3 2.3" /><path d="m11 10.7 2.3 2.3" /></svg>
                 <span>Upload</span>
               </button>
-              <button id="cameraCaptureBtn" type="button" class="flex h-12 w-12 flex-col items-center justify-center rounded-lg bg-white/5 text-xs text-slate-300 transition hover:bg-white/10">
+              <button id="cameraCaptureBtn" type="button" class="button button--ghost button--stacked">
                 <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3z" /><circle cx="12" cy="13" r="3" /></svg>
                 <span>Camera</span>
               </button>
@@ -88,10 +88,10 @@
           <div class="relative">
             <textarea id="userInput" rows="1" placeholder="Ask a question..." class="w-full resize-none rounded-lg border border-white/10 bg-slate-800/70 py-3 pl-4 pr-28 text-slate-100 placeholder:text-slate-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/50"></textarea>
             <div class="absolute bottom-2 right-2 flex items-center gap-2">
-              <button id="stopBtn" type="button" class="hidden h-9 w-9 items-center justify-center rounded-lg bg-rose-500/90 text-white transition hover:bg-rose-500" title="Stop generation">
+              <button id="stopBtn" type="button" class="button button--icon button--danger hidden" title="Stop generation">
                 <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor"><rect x="7" y="7" width="10" height="10" rx="1" /></svg>
               </button>
-              <button id="sendBtn" type="button" class="flex h-9 w-16 items-center justify-center rounded-lg bg-indigo-500 text-sm font-semibold text-white transition hover:bg-indigo-600" title="Send message">
+              <button id="sendBtn" type="button" class="button button--primary" title="Send message">
                 <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13" /><polygon points="22 2 15 22 11 13 2 9 22 2" /></svg>
               </button>
             </div>
@@ -104,7 +104,7 @@
     <aside id="settingsDrawer" class="fixed right-0 top-0 z-50 flex h-full w-full max-w-md translate-x-full flex-col bg-slate-900/95 text-slate-100 shadow-2xl backdrop-blur-lg transition-transform duration-300">
       <div class="flex items-center justify-between border-b border-white/10 p-4">
         <h2 class="text-lg font-semibold text-white">Settings</h2>
-        <button id="closeSettings" type="button" class="h-8 w-8 rounded-lg text-slate-400 transition hover:bg-white/10 hover:text-white">
+        <button id="closeSettings" type="button" class="button button--icon-sm button--ghost">
           <svg class="m-auto h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
         </button>
       </div>
@@ -119,7 +119,7 @@
             <select id="modelSelect" class="flex-1 rounded-lg border border-white/10 bg-slate-800/70 p-2 text-sm text-slate-100 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500">
               <option value="">Select a model</option>
             </select>
-            <button id="refreshModels" type="button" class="h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg border border-white/10 bg-white/5 text-slate-300 transition hover:bg-white/10" title="Refresh models">
+            <button id="refreshModels" type="button" class="button button--icon button--ghost flex-shrink-0" title="Refresh models">
               <svg class="m-auto h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" /><path d="M21 3v5h-5" /></svg>
             </button>
           </div>
@@ -153,7 +153,7 @@
           <label class="text-sm font-medium text-slate-300">System Prompt</label>
           <textarea id="systemPrompt" rows="4" class="w-full resize-y rounded-lg border border-white/10 bg-slate-800/70 p-2 text-sm text-slate-100 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500" placeholder="You are a helpful assistant."></textarea>
           <div class="flex flex-wrap items-center gap-2">
-            <button id="savePromptBtn" type="button" class="rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-medium text-slate-300 transition hover:bg-white/10">Save to Library</button>
+            <button id="savePromptBtn" type="button" class="button button--ghost button--muted">Save to Library</button>
             <select id="promptLibrarySelect" class="flex-1 rounded-lg border border-white/10 bg-slate-800/70 p-1.5 text-xs text-slate-300 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500">
               <option value="">Load from Library</option>
             </select>
@@ -161,7 +161,7 @@
         </div>
       </form>
       <div class="border-t border-white/10 p-4">
-        <button id="saveSettings" type="button" class="w-full rounded-lg bg-indigo-600 py-2.5 text-sm font-semibold text-white transition hover:bg-indigo-700">Save and Close</button>
+        <button id="saveSettings" type="button" class="button button--primary button--block">Save and Close</button>
       </div>
     </aside>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -87,7 +87,7 @@
           <div id="sessionStats" class="session-stats hidden" aria-live="polite"></div>
           <div class="relative">
             <textarea id="userInput" rows="1" placeholder="Ask a question..." class="w-full resize-none rounded-lg border border-white/10 bg-slate-800/70 py-3 pl-4 pr-28 text-slate-100 placeholder:text-slate-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/50"></textarea>
-            <div class="absolute bottom-2 right-2 flex items-center gap-2">
+            <div class="absolute right-2 top-1/2 flex -translate-y-1/2 transform items-center gap-2">
               <button id="stopBtn" type="button" class="button button--icon button--danger hidden" title="Stop generation">
                 <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor"><rect x="7" y="7" width="10" height="10" rx="1" /></svg>
               </button>


### PR DESCRIPTION
## Summary
- capture latency and token usage from chat completions on the backend and persist running totals per session
- extend the chat UI to surface per-message latency/token metadata and display a session token summary
- style the new metadata chips so they stay subtle and remain outside rendered markdown content

## Testing
- python -m compileall . *(fails: existing syntax error in write_app_js.py)*

------
https://chatgpt.com/codex/tasks/task_e_68d5f8a174f08326a80dfa95c9217868