### PR TITLE
Manage drawer-open class on settings drawer

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,5 +1,6 @@
 document.addEventListener("DOMContentLoaded", () => {
   const el = (s) => document.querySelector(s);
+  document.body.classList.remove("drawer-open");
   const converter = new showdown.Converter({
     ghCompatibleHeaderId: true,
     simpleLineBreaks: true,
@@ -525,9 +526,11 @@ document.addEventListener("DOMContentLoaded", () => {
   openSettingsBtn.addEventListener("click", () => {
     settingsOverlay.classList.remove("hidden");
     settingsDrawer.classList.remove("translate-x-full");
+    document.body.classList.add("drawer-open");
   });
 
   const closeDrawer = () => {
+    document.body.classList.remove("drawer-open");
     settingsOverlay.classList.add("hidden");
     settingsDrawer.classList.add("translate-x-full");
   };


### PR DESCRIPTION
## Summary
- add a defensive reset for the `drawer-open` body class during initialization
- toggle the `drawer-open` class when opening and closing the settings drawer

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6105c927083269e5008095b921ec0