### PR TITLE
Add accessible label for chat textarea

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -86,6 +86,7 @@
           </div>
           <div id="sessionStats" class="session-stats hidden" aria-live="polite"></div>
           <div class="relative">
+            <label for="userInput" class="sr-only">Message</label>
             <textarea id="userInput" rows="1" placeholder="Ask a question..." class="w-full resize-none rounded-lg border border-white/10 bg-slate-800/70 py-3 pl-4 pr-28 text-slate-100 placeholder:text-slate-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/50"></textarea>
             <div class="absolute right-2 top-1/2 flex -translate-y-1/2 transform items-center gap-2">
               <button id="stopBtn" type="button" class="button button--icon button--danger hidden" title="Stop generation">


### PR DESCRIPTION
## Summary
- add a visually hidden label for the chat textarea to improve accessibility

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d61079abc88326aa933b9eaa991975