### PR TITLE
Add animated typing indicator styling

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -265,3 +265,23 @@ body {
 body.drawer-open {
   overflow: hidden;
 }
+
+.typing {
+  display: inline-block;
+  animation: typingPulse 1s ease-in-out infinite;
+}
+
+@keyframes typingPulse {
+  0% {
+    opacity: 0.35;
+    transform: translateY(0);
+  }
+  50% {
+    opacity: 1;
+    transform: translateY(-1px);
+  }
+  100% {
+    opacity: 0.35;
+    transform: translateY(0);
+  }
+}

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -329,7 +329,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const aiMessage = addMessage("ai", "");
     const cursor = document.createElement("span");
     cursor.className = "typing";
-    cursor.textContent = "▍";
+    cursor.textContent = "…";
     aiMessage.content.appendChild(cursor);
 
     sendBtn.classList.add("hidden");


### PR DESCRIPTION
## Summary
- add a reusable `.typing` style with a subtle pulse animation for streaming cursors
- swap the assistant cursor glyph to an ellipsis so it matches the new animation

## Testing
- python app.py *(fails to fetch remote models in sandbox; UI served locally for verification)*

------
https://chatgpt.com/codex/tasks/task_e_68d611f9bc0883269cd30427d718e3bb