### PR TITLE
Improve image preview layout alignment

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -172,6 +172,12 @@ body {
   border-color: rgba(100, 116, 139, 0.6);
 }
 
+.image-preview {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
 .bubble-footer {
   margin-top: 0.75rem;
   display: flex;

--- a/templates/index.html
+++ b/templates/index.html
@@ -61,7 +61,7 @@
       <footer class="mt-4">
         <div class="rounded-2xl border border-white/10 bg-slate-900/70 p-3 backdrop-blur-md">
           <div id="visionTools" class="mb-2 hidden items-center gap-2 border-b border-white/10 pb-3">
-            <div id="imagePreview" class="hidden items-center gap-2">
+            <div id="imagePreview" class="image-preview hidden flex items-center gap-3">
               <img id="imagePreviewImg" src="" alt="Preview" class="h-12 w-12 rounded-lg object-cover">
               <div>
                 <p id="imagePreviewMeta" class="text-xs font-medium text-slate-200"></p>


### PR DESCRIPTION
## Summary
- enable Tailwind gap utilities on the image preview wrapper by making it a flex container
- add a CSS fallback to guarantee aligned, well-spaced preview contents on larger screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d61456c0988326942fc9b8a7950622