### PR TITLE
Hide assistant metrics until hover

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -345,6 +345,7 @@ input[type="range"]:disabled::-ms-thumb {
   align-self: flex-end;
   align-items: flex-end;
   gap: 0.35rem;
+  position: relative;
 }
 
 .bubble-footer__toggle {
@@ -406,8 +407,7 @@ input[type="range"]:disabled::-ms-thumb {
     padding 180ms ease;
 }
 
-.bubble-footer__toggle:is(:hover, :focus, :focus-visible) + .bubble-footer,
-.bubble-footer:hover,
+.bubble-footer-wrapper.is-active .bubble-footer,
 .bubble-footer:focus-within {
   opacity: 1;
   max-height: 220px;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -333,14 +333,42 @@ input[type="range"]:disabled::-ms-thumb {
   align-items: center;
 }
 
-.bubble-footer {
+.bubble-footer-wrapper {
   margin-top: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  position: relative;
+}
+
+.bubble-footer__hover-zone {
+  width: calc(100% + 1.5rem);
+  height: 0.6rem;
+  margin-left: -0.75rem;
+  margin-right: -0.75rem;
+  margin-bottom: 0.35rem;
+  border-radius: 9999px;
+  cursor: pointer;
+}
+
+.bubble-footer {
   display: flex;
   flex-wrap: wrap;
   gap: 0.35rem;
   font-size: 0.65rem;
   line-height: 1.1;
   color: #94a3b8;
+  opacity: 0;
+  transform: translateY(6px);
+  pointer-events: none;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+.bubble-footer-wrapper:hover .bubble-footer,
+.bubble-footer-wrapper:focus-within .bubble-footer {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
 }
 
 .bubble-footer__item {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -333,22 +333,56 @@ input[type="range"]:disabled::-ms-thumb {
   align-items: center;
 }
 
-.bubble-footer-wrapper {
-  margin-top: 0.75rem;
+.bubble--ai {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  position: relative;
 }
 
-.bubble-footer__hover-zone {
-  width: calc(100% + 1.5rem);
-  height: 0.6rem;
-  margin-left: -0.75rem;
-  margin-right: -0.75rem;
-  margin-bottom: 0.35rem;
+.bubble-footer-wrapper {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  align-self: flex-end;
+  align-items: flex-end;
+  gap: 0.35rem;
+}
+
+.bubble-footer__toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
   border-radius: 9999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(30, 41, 59, 0.85);
+  color: #cbd5f5;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: lowercase;
   cursor: pointer;
+  padding: 0;
+  transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease,
+    box-shadow 160ms ease, transform 160ms ease;
+}
+
+.bubble-footer__toggle:hover {
+  background: rgba(99, 102, 241, 0.2);
+  border-color: rgba(129, 140, 248, 0.5);
+  color: #f8fafc;
+  transform: translateY(-1px);
+}
+
+.bubble-footer__toggle:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.45);
+  background: rgba(99, 102, 241, 0.22);
+  border-color: rgba(129, 140, 248, 0.65);
+  color: #f8fafc;
+}
+
+.bubble-footer__toggle span {
+  pointer-events: none;
 }
 
 .bubble-footer {
@@ -358,17 +392,27 @@ input[type="range"]:disabled::-ms-thumb {
   font-size: 0.65rem;
   line-height: 1.1;
   color: #94a3b8;
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 0.9rem;
+  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.4);
+  padding: 0;
   opacity: 0;
-  transform: translateY(6px);
+  max-height: 0;
+  overflow: hidden;
   pointer-events: none;
-  transition: opacity 180ms ease, transform 180ms ease;
+  transform: translateY(6px);
+  transition: opacity 180ms ease, transform 180ms ease, max-height 180ms ease,
+    padding 180ms ease;
 }
 
 .bubble-footer-wrapper:hover .bubble-footer,
 .bubble-footer-wrapper:focus-within .bubble-footer {
   opacity: 1;
-  transform: translateY(0);
+  max-height: 220px;
+  padding: 0.45rem 0.55rem;
   pointer-events: auto;
+  transform: translateY(0);
 }
 
 .bubble-footer__item {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -406,8 +406,9 @@ input[type="range"]:disabled::-ms-thumb {
     padding 180ms ease;
 }
 
-.bubble-footer-wrapper:hover .bubble-footer,
-.bubble-footer-wrapper:focus-within .bubble-footer {
+.bubble-footer__toggle:is(:hover, :focus, :focus-visible) + .bubble-footer,
+.bubble-footer:hover,
+.bubble-footer:focus-within {
   opacity: 1;
   max-height: 220px;
   padding: 0.45rem 0.55rem;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -173,9 +173,19 @@ document.addEventListener("DOMContentLoaded", () => {
 
     let footer = null;
     if (role === "ai") {
+      const footerWrapper = document.createElement("div");
+      footerWrapper.className = "bubble-footer-wrapper hidden";
+
+      const hoverZone = document.createElement("div");
+      hoverZone.className = "bubble-footer__hover-zone";
+      hoverZone.setAttribute("aria-hidden", "true");
+      footerWrapper.appendChild(hoverZone);
+
       footer = document.createElement("div");
       footer.className = "bubble-footer hidden";
-      bubble.appendChild(footer);
+      footerWrapper.appendChild(footer);
+
+      bubble.appendChild(footerWrapper);
     }
 
     wrapper.appendChild(bubble);
@@ -207,6 +217,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
     footerEl.innerHTML = "";
     const segments = [];
+
+    const wrapperEl = footerEl.parentElement;
 
     const meta = metadata || {};
     const { prompt, completion, total, serverLatency, roundTripMs } = meta;
@@ -247,11 +259,13 @@ document.addEventListener("DOMContentLoaded", () => {
 
     if (!segments.length) {
       footerEl.classList.add("hidden");
+      wrapperEl?.classList.add("hidden");
       return;
     }
 
     segments.forEach((segment) => footerEl.appendChild(segment));
     footerEl.classList.remove("hidden");
+    wrapperEl?.classList.remove("hidden");
   }
 
   function updateSessionStats(totals) {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -156,6 +156,7 @@ document.addEventListener("DOMContentLoaded", () => {
     } else {
       wrapper.classList.add("justify-start");
       bubble.classList.add("bg-slate-800", "text-slate-200");
+      bubble.classList.add("bubble--ai");
     }
 
     if (attachment) {
@@ -176,10 +177,13 @@ document.addEventListener("DOMContentLoaded", () => {
       const footerWrapper = document.createElement("div");
       footerWrapper.className = "bubble-footer-wrapper hidden";
 
-      const hoverZone = document.createElement("div");
-      hoverZone.className = "bubble-footer__hover-zone";
-      hoverZone.setAttribute("aria-hidden", "true");
-      footerWrapper.appendChild(hoverZone);
+      const infoToggle = document.createElement("button");
+      infoToggle.type = "button";
+      infoToggle.className = "bubble-footer__toggle";
+      infoToggle.setAttribute("aria-label", "Show message details");
+      infoToggle.setAttribute("title", "Show message details");
+      infoToggle.innerHTML = '<span aria-hidden="true">i</span>';
+      footerWrapper.appendChild(infoToggle);
 
       footer = document.createElement("div");
       footer.className = "bubble-footer hidden";

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -187,6 +187,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
       footer = document.createElement("div");
       footer.className = "bubble-footer hidden";
+      footer.setAttribute("aria-hidden", "true");
       footerWrapper.appendChild(footer);
 
       bubble.appendChild(footerWrapper);
@@ -214,6 +215,87 @@ document.addEventListener("DOMContentLoaded", () => {
     span.appendChild(valueSpan);
 
     return span;
+  }
+
+  function setupFooterInteractions(wrapperEl, footerEl) {
+    if (!wrapperEl || !footerEl || wrapperEl.dataset.footerReady === "true") {
+      return;
+    }
+
+    const toggleBtn = wrapperEl.querySelector(".bubble-footer__toggle");
+    const bubbleEl = wrapperEl.closest(".bubble");
+    if (!toggleBtn || !bubbleEl) return;
+
+    wrapperEl.dataset.footerReady = "true";
+    toggleBtn.setAttribute("aria-expanded", "false");
+
+    let hoverTimer = null;
+    let isActive = false;
+
+    const clearHoverTimer = () => {
+      if (hoverTimer) {
+        clearTimeout(hoverTimer);
+        hoverTimer = null;
+      }
+    };
+
+    const activate = () => {
+      if (isActive) return;
+      wrapperEl.classList.add("is-active");
+      wrapperEl.classList.remove("hidden");
+      footerEl.classList.remove("hidden");
+      footerEl.setAttribute("aria-hidden", "false");
+      toggleBtn.setAttribute("aria-expanded", "true");
+      isActive = true;
+    };
+
+    const deactivate = () => {
+      if (!isActive) return;
+      wrapperEl.classList.remove("is-active");
+      footerEl.setAttribute("aria-hidden", "true");
+      toggleBtn.setAttribute("aria-expanded", "false");
+      isActive = false;
+    };
+
+    toggleBtn.addEventListener("mouseenter", () => {
+      clearHoverTimer();
+      hoverTimer = setTimeout(() => {
+        activate();
+      }, 500);
+    });
+
+    toggleBtn.addEventListener("mouseleave", () => {
+      clearHoverTimer();
+    });
+
+    toggleBtn.addEventListener("click", (event) => {
+      event.preventDefault();
+      clearHoverTimer();
+      activate();
+    });
+
+    toggleBtn.addEventListener("focus", () => {
+      clearHoverTimer();
+      activate();
+    });
+
+    toggleBtn.addEventListener("blur", (event) => {
+      const next = event.relatedTarget;
+      if (next && bubbleEl.contains(next)) {
+        return;
+      }
+      clearHoverTimer();
+      deactivate();
+    });
+
+    bubbleEl.addEventListener("mouseleave", (event) => {
+      const next = event.relatedTarget;
+      if (next && bubbleEl.contains(next)) {
+        return;
+      }
+      clearHoverTimer();
+      deactivate();
+    });
   }
 
   function updateAssistantFooter(footerEl, metadata) {
@@ -263,6 +345,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
     if (!segments.length) {
       footerEl.classList.add("hidden");
+      footerEl.setAttribute("aria-hidden", "true");
+      wrapperEl?.classList.remove("is-active");
       wrapperEl?.classList.add("hidden");
       return;
     }
@@ -270,6 +354,8 @@ document.addEventListener("DOMContentLoaded", () => {
     segments.forEach((segment) => footerEl.appendChild(segment));
     footerEl.classList.remove("hidden");
     wrapperEl?.classList.remove("hidden");
+    footerEl.setAttribute("aria-hidden", "true");
+    setupFooterInteractions(wrapperEl, footerEl);
   }
 
   function updateSessionStats(totals) {


### PR DESCRIPTION
## Summary
- wrap assistant message metadata in a hover-revealed container so the tokens and latency stay hidden until needed
- add CSS transitions and a hover zone that reveals the metrics only when hovering near the bottom of an AI message

## Testing
- python app.py

------
https://chatgpt.com/codex/tasks/task_e_68d6482650b4832699fbcdcd2d1a7e90